### PR TITLE
Use prisma field equals functions

### DIFF
--- a/packages/core/src/functions/elements.rs
+++ b/packages/core/src/functions/elements.rs
@@ -74,7 +74,7 @@ pub async fn create_element(
             .create(
                 value.r#type,
                 value.content,
-                prisma::spaces::UniqueWhereParam::IdEquals(data.space_id),
+                prisma::spaces::id::equals(data.space_id),
                 vec![],
             )
             .exec()

--- a/packages/core/src/functions/spaces.rs
+++ b/packages/core/src/functions/spaces.rs
@@ -67,7 +67,7 @@ pub async fn update_space_indexes(
         let space = client
             .spaces()
             .upsert(
-                prisma::spaces::UniqueWhereParam::IdEquals(space.id.clone()),
+                prisma::spaces::id::equals(space.id.clone()),
                 (
                     "Space ".to_owned() + &(space.id + 1).to_string(),
                     String::new(),


### PR DESCRIPTION
I wouldn't recommend using `UniqueWhereParam` directly, it and other enums are more of an internal API. It's not really documented but `equals` is able to return either `WhereParam` or `UniqueWhereParam` depending on where you use it.
I'm curious why this was done in the first place? Seems like we accidentally do the same thing [here](https://github.com/spacedriveapp/spacedrive/blob/fe529543a911d0b1aace7a2434a3776dcfd75673/core/src/tag/mod.rs#L135-L136) so I can understand if you were just taking inspiration from Spacedrive, or do I need to make the docs more explanatory?